### PR TITLE
fix(replyTranslate): Use @vitalets/google-translate-api

### DIFF
--- a/app/actions/replyTranslate.js
+++ b/app/actions/replyTranslate.js
@@ -1,5 +1,5 @@
 const { commentIssue } = require('../../lib/github');
-const translate = require('google-translate-api');
+const translate = require('@vitalets/google-translate-api');
 
 function containsChinese(title) {
   return /[\u4e00-\u9fa5]/.test(title);

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "node": ">=8"
   },
   "dependencies": {
+    "@vitalets/google-translate-api": "^3.0.0",
     "axios": "^0.19.0",
     "cryptiles": "^4.1.2",
     "dotenv": "^8.0.0",
     "duration-js": "^4.0.0",
     "github": "^9.2.0",
-    "google-translate-api": "^2.3.0",
     "koa": "^2.7.0",
     "koa-bodyparser": "4.2.1",
     "koa-logger": "^3.2.1",


### PR DESCRIPTION
- Use [@vitalets/google-translate-api](https://github.com/vitalets/google-translate-api) to replace [google-translate-api](https://github.com/matheuss/google-translate-api). 
- Ref: https://github.com/matheuss/google-translate-api/issues/79#issuecomment-427841889